### PR TITLE
Import Node performance in sync logic

### DIFF
--- a/src/syncLogic.ts
+++ b/src/syncLogic.ts
@@ -1,3 +1,4 @@
+import { performance } from 'perf_hooks';
 import { Notice } from 'obsidian';
 import { ErrorHandler, DateUtils, FingerprintUtils } from './commonUtils';
 import { rrulestr } from 'rrule';


### PR DESCRIPTION
## Summary
- import Node's `performance` from `perf_hooks` in `syncLogic`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68b67f5f84f48320875aeca680c3ba74