### PR TITLE
refactor: modularize initialization

### DIFF
--- a/src/init/autoSync.ts
+++ b/src/init/autoSync.ts
@@ -1,0 +1,33 @@
+import moment from 'moment';
+import type GoogleCalendarTasksSyncPlugin from '../main';
+
+export function setupAutoSyncTimer(plugin: GoogleCalendarTasksSyncPlugin): void {
+    plugin.clearAutoSync();
+    if (plugin.settings.autoSync && plugin.settings.syncIntervalMinutes >= 1) {
+        const intervalMillis = plugin.settings.syncIntervalMinutes * 60 * 1000;
+        console.log(`自動同期を ${plugin.settings.syncIntervalMinutes} 分ごとに設定します。`);
+        plugin.syncIntervalId = window.setInterval(async () => {
+            const timestamp = moment().format('HH:mm:ss');
+            console.log(`[${timestamp}] 自動同期トリガー`);
+            if (plugin.isCurrentlySyncing()) {
+                console.warn(`[${timestamp}] 自動同期スキップ: 実行中`);
+                return;
+            }
+            if (!plugin.settings.tokens) {
+                console.warn(`[${timestamp}] 自動同期スキップ: 未認証`);
+                return;
+            }
+            const tokenReady = await plugin.authService.ensureAccessToken();
+            if (!tokenReady) {
+                console.warn(`[${timestamp}] 自動同期スキップ: トークン取得失敗`);
+                return;
+            }
+            console.log(`[${timestamp}] 自動同期実行中...`);
+            await plugin.syncLogic.runSync(JSON.parse(JSON.stringify(plugin.settings)));
+            console.log(`[${timestamp}] 自動同期完了`);
+        }, intervalMillis);
+        console.log(`自動同期タイマー開始 (ID: ${plugin.syncIntervalId})。初回実行は約 ${moment().add(intervalMillis, 'ms').format('HH:mm')}。`);
+    } else {
+        console.log(`自動同期は無効です (有効: ${plugin.settings.autoSync}, 間隔: ${plugin.settings.syncIntervalMinutes} 分)。`);
+    }
+}

--- a/src/init/commands.ts
+++ b/src/init/commands.ts
@@ -1,0 +1,36 @@
+import type GoogleCalendarTasksSyncPlugin from '../main';
+import { Notice } from 'obsidian';
+
+export function registerCommands(plugin: GoogleCalendarTasksSyncPlugin): void {
+    plugin.addCommand({
+        id: 'authenticate-with-google',
+        name: 'Google で認証する',
+        callback: () => plugin.authService.authenticate(),
+    });
+
+    plugin.addCommand({
+        id: 'sync-tasks-now',
+        name: 'Google Calendar と今すぐタスクを同期する',
+        callback: async () => plugin.triggerSync(),
+    });
+
+    plugin.addCommand({
+        id: 'dedupe-cleanup-dry-run',
+        name: '重複イベントを整理（ドライラン）',
+        callback: async () => {
+            if (plugin.isCurrentlySyncing()) { new Notice('処理中のため実行できない。'); return; }
+            await plugin.syncLogic.runDedupeCleanup(true);
+        }
+    });
+
+    plugin.addCommand({
+        id: 'dedupe-cleanup-exec',
+        name: '重複イベントを整理（実行）',
+        callback: async () => {
+            if (plugin.isCurrentlySyncing()) { new Notice('処理中のため実行できない。'); return; }
+            const ok = confirm('重複イベントの削除を実行しますか？ この操作は元に戻せません。');
+            if (!ok) return;
+            await plugin.syncLogic.runDedupeCleanup(false);
+        }
+    });
+}

--- a/src/init/oauth.ts
+++ b/src/init/oauth.ts
@@ -1,0 +1,14 @@
+import type GoogleCalendarTasksSyncPlugin from '../main';
+
+export async function initializeOAuth(plugin: GoogleCalendarTasksSyncPlugin): Promise<void> {
+    if (!plugin.settings.useLoopbackServer) {
+        console.log("'useLoopbackServer' を true に強制します (唯一のサポート方法)。");
+        plugin.settings.useLoopbackServer = true;
+    }
+
+    plugin.authService.reconfigureOAuthClient();
+    plugin.authService.initializeCalendarApi();
+
+    await plugin.httpServerManager.stopServer();
+    plugin.httpServerManager.startServer();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,9 @@ import { SyncLogic } from './syncLogic';
 import { validateMoment } from './utils'; // ユーティリティ関数をインポート
 import { encryptWithPassphrase, decryptWithPassphrase, obfuscateToBase64, deobfuscateFromBase64, deobfuscateLegacyFromBase64 } from './security';
 import { setDevLogging } from './logger';
+import { registerCommands as initRegisterCommands } from './init/commands';
+import { initializeOAuth as initOAuth } from './init/oauth';
+import { setupAutoSyncTimer as initAutoSyncTimer } from './init/autoSync';
 
 export default class GoogleCalendarTasksSyncPlugin extends Plugin {
 	settings: GoogleCalendarTasksSyncSettings;
@@ -43,134 +46,123 @@ export default class GoogleCalendarTasksSyncPlugin extends Plugin {
     }
 
 
-	async onload() {
-		console.log('Google Calendar Sync プラグインをロード中');
-		await this.loadSettings();
-        setDevLogging(!!this.settings.devLogging);
+        async onload() {
+                console.log('Google Calendar Sync プラグインをロード中');
+                await this.loadSettings();
+                setDevLogging(!!this.settings.devLogging);
 
-        // 設定がロードされた後に、設定に依存するクラスをインスタンス化
-        this.syncLogic = new SyncLogic(this);
+                // 設定がロードされた後に、設定に依存するクラスをインスタンス化
+                this.syncLogic = new SyncLogic(this);
 
-		// useLoopbackServer の強制 (現在は不要だが念のため)
-		if (!this.settings.useLoopbackServer) {
-			console.log("'useLoopbackServer' を true に強制します (唯一のサポート方法)。");
-			this.settings.useLoopbackServer = true;
-		}
+                await this.initializeOAuth();
+                this.registerCommands();
+                // 設定タブの追加
+                this.addSettingTab(new GoogleCalendarSyncSettingTab(this.app, this));
+                // 自動同期のセットアップ
+                this.setupAutoSyncTimer();
 
-		// OAuth クライアントと API クライアントの初期化
-		this.authService.reconfigureOAuthClient();
-		this.authService.initializeCalendarApi();
-
-		// HTTP サーバーの起動
-		await this.httpServerManager.stopServer(); // 念のため既存を停止
-		this.httpServerManager.startServer();
-
-		// コマンド登録
-		this.addCommand({
-			id: 'authenticate-with-google',
-			name: 'Google で認証する',
-			callback: () => this.authService.authenticate(),
-		});
-
-		this.addCommand({
-			id: 'sync-tasks-now',
-			name: 'Google Calendar と今すぐタスクを同期する',
-			callback: async () => this.triggerSync(),
-		});
-
-		// 重複整理（ドライラン）
-		this.addCommand({
-			id: 'dedupe-cleanup-dry-run',
-			name: '重複イベントを整理（ドライラン）',
-			callback: async () => {
-				if (this.isCurrentlySyncing()) { new Notice('処理中のため実行できない。'); return; }
-				await this.syncLogic.runDedupeCleanup(true);
-			}
-		});
-
-		// 重複整理（実行）
-		this.addCommand({
-			id: 'dedupe-cleanup-exec',
-			name: '重複イベントを整理（実行）',
-			callback: async () => {
-				if (this.isCurrentlySyncing()) { new Notice('処理中のため実行できない。'); return; }
-				const ok = confirm('重複イベントの削除を実行しますか？ この操作は元に戻せません。');
-				if (!ok) return;
-				await this.syncLogic.runDedupeCleanup(false);
-			}
-		});
-
-		// 設定タブの追加
-		this.addSettingTab(new GoogleCalendarSyncSettingTab(this.app, this));
-
-		// 自動同期のセットアップ
-		this.setupAutoSync();
-
-		console.log('Google Calendar Sync プラグインがロードされました。');
-	}
-
-	async onunload() {
-		console.log('Google Calendar Sync プラグインをアンロード中');
-		this.clearAutoSync();
-		await this.httpServerManager.stopServer();
-		console.log('Google Calendar Sync プラグインがアンロードされました。');
-	}
-
-	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-		// 設定値の検証と修正
-		if (!this.settings.taskMap || typeof this.settings.taskMap !== 'object') {
-			this.settings.taskMap = {};
-		}
-		this.settings.useLoopbackServer = true; // 強制
-		if (typeof this.settings.loopbackPort !== 'number' || !Number.isInteger(this.settings.loopbackPort) || this.settings.loopbackPort < 1024 || this.settings.loopbackPort > 65535) {
-			console.warn(`無効なループバックポート "${this.settings.loopbackPort}"。デフォルト ${DEFAULT_SETTINGS.loopbackPort} にリセット。`);
-			this.settings.loopbackPort = DEFAULT_SETTINGS.loopbackPort;
-		}
-		if (typeof this.settings.defaultEventDurationMinutes !== 'number' || !Number.isInteger(this.settings.defaultEventDurationMinutes) || this.settings.defaultEventDurationMinutes < 5) {
-			console.warn(`無効なデフォルト期間 "${this.settings.defaultEventDurationMinutes}"。デフォルト ${DEFAULT_SETTINGS.defaultEventDurationMinutes} にリセット。`);
-			this.settings.defaultEventDurationMinutes = DEFAULT_SETTINGS.defaultEventDurationMinutes;
-		}
-		if (typeof this.settings.syncIntervalMinutes !== 'number' || !Number.isInteger(this.settings.syncIntervalMinutes) || this.settings.syncIntervalMinutes < 1) {
-			console.warn(`無効な同期間隔 "${this.settings.syncIntervalMinutes}"。デフォルト ${DEFAULT_SETTINGS.syncIntervalMinutes} にリセット。`);
-			this.settings.syncIntervalMinutes = DEFAULT_SETTINGS.syncIntervalMinutes;
-		}
-		if (this.settings.lastSyncTime && !validateMoment(this.settings.lastSyncTime, [moment.ISO_8601 as any, "YYYY-MM-DDTHH:mm:ssZ"], "lastSyncTime")) {
-            console.warn(`無効な lastSyncTime "${this.settings.lastSyncTime}"。クリアします。`);
-			this.settings.lastSyncTime = undefined;
+                console.log('Google Calendar Sync プラグインがロードされました。');
         }
 
-        // 暗号化/難読化トークン（refresh_tokenのみ）の復号
-        try {
-            if (this.settings.tokensEncrypted && !this.settings.tokens?.refresh_token) {
-                let json: string | null = null;
-                if (this.settings.tokensEncrypted.startsWith('aesgcm:')) {
-                    const pass = this.passphraseCache || this.settings.encryptionPassphrase || null;
-                    if (pass) {
-                        const inner = decryptWithPassphrase(this.settings.tokensEncrypted, pass);
-                        json = deobfuscateFromBase64(inner, this.settings.obfuscationSalt!);
-                    } else {
-                        console.warn('暗号化トークンが存在しますが、パスフレーズが未設定のため復号できません。');
-                        new Notice('暗号化されたトークンを復号できません。設定でパスフレーズを入力し、再試行してください。', 10000);
-                    }
-                } else if (this.settings.tokensEncrypted.startsWith('obf1:')) {
-                    json = deobfuscateFromBase64(this.settings.tokensEncrypted, this.settings.obfuscationSalt!);
-                } else if (this.settings.tokensEncrypted.startsWith('obf:')) {
-                    // レガシー形式: 旧XORで復号 → 新形式へ再保存
-                    json = deobfuscateLegacyFromBase64(this.settings.tokensEncrypted, this.settings.obfuscationSalt || '');
-                    try { const { refresh_token } = JSON.parse(json); if (refresh_token) await this.persistTokens({ refresh_token }); } catch {}
-                }
-                if (json) {
-                    const { refresh_token } = JSON.parse(json);
-                    if (refresh_token) this.settings.tokens = { refresh_token } as any;
-                }
-            }
-        } catch (e) {
-            console.error('暗号化トークンの復号に失敗:', e);
+        async onunload() {
+                console.log('Google Calendar Sync プラグインをアンロード中');
+                this.clearAutoSync();
+                await this.httpServerManager.stopServer();
+                console.log('Google Calendar Sync プラグインがアンロードされました。');
         }
 
-        // syncLogic はコンストラクタで plugin インスタンスを受け取るだけなので再インスタンス化不要
-	}
+        async loadSettings() {
+                this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+                this.validateSettings();
+                await this.decryptStoredTokens();
+                // syncLogic はコンストラクタで plugin インスタンスを受け取るだけなので再インスタンス化不要
+        }
+
+        private validateSettings(): void {
+                // 設定値の検証と修正
+                if (!this.settings.taskMap || typeof this.settings.taskMap !== 'object') {
+                        this.settings.taskMap = {};
+                }
+                this.settings.useLoopbackServer = true; // 強制
+                if (
+                        typeof this.settings.loopbackPort !== 'number' ||
+                        !Number.isInteger(this.settings.loopbackPort) ||
+                        this.settings.loopbackPort < 1024 ||
+                        this.settings.loopbackPort > 65535
+                ) {
+                        console.warn(`無効なループバックポート "${this.settings.loopbackPort}"。デフォルト ${DEFAULT_SETTINGS.loopbackPort} にリセット。`);
+                        this.settings.loopbackPort = DEFAULT_SETTINGS.loopbackPort;
+                }
+                if (
+                        typeof this.settings.defaultEventDurationMinutes !== 'number' ||
+                        !Number.isInteger(this.settings.defaultEventDurationMinutes) ||
+                        this.settings.defaultEventDurationMinutes < 5
+                ) {
+                        console.warn(`無効なデフォルト期間 "${this.settings.defaultEventDurationMinutes}"。デフォルト ${DEFAULT_SETTINGS.defaultEventDurationMinutes} にリセット。`);
+                        this.settings.defaultEventDurationMinutes = DEFAULT_SETTINGS.defaultEventDurationMinutes;
+                }
+                if (
+                        typeof this.settings.syncIntervalMinutes !== 'number' ||
+                        !Number.isInteger(this.settings.syncIntervalMinutes) ||
+                        this.settings.syncIntervalMinutes < 1
+                ) {
+                        console.warn(`無効な同期間隔 "${this.settings.syncIntervalMinutes}"。デフォルト ${DEFAULT_SETTINGS.syncIntervalMinutes} にリセット。`);
+                        this.settings.syncIntervalMinutes = DEFAULT_SETTINGS.syncIntervalMinutes;
+                }
+                if (
+                        this.settings.lastSyncTime &&
+                        !validateMoment(this.settings.lastSyncTime, [moment.ISO_8601 as any, 'YYYY-MM-DDTHH:mm:ssZ'], 'lastSyncTime')
+                ) {
+                        console.warn(`無効な lastSyncTime "${this.settings.lastSyncTime}"。クリアします。`);
+                        this.settings.lastSyncTime = undefined;
+                }
+        }
+
+        private async decryptStoredTokens(): Promise<void> {
+                // 暗号化/難読化トークン（refresh_tokenのみ）の復号
+                try {
+                        if (this.settings.tokensEncrypted && !this.settings.tokens?.refresh_token) {
+                                let json: string | null = null;
+                                if (this.settings.tokensEncrypted.startsWith('aesgcm:')) {
+                                        const pass = this.passphraseCache || this.settings.encryptionPassphrase || null;
+                                        if (pass) {
+                                                const inner = decryptWithPassphrase(this.settings.tokensEncrypted, pass);
+                                                json = deobfuscateFromBase64(inner, this.settings.obfuscationSalt!);
+                                        } else {
+                                                console.warn('暗号化トークンが存在しますが、パスフレーズが未設定のため復号できません。');
+                                                new Notice('暗号化されたトークンを復号できません。設定でパスフレーズを入力し、再試行してください。', 10000);
+                                        }
+                                } else if (this.settings.tokensEncrypted.startsWith('obf1:')) {
+                                        json = deobfuscateFromBase64(this.settings.tokensEncrypted, this.settings.obfuscationSalt!);
+                                } else if (this.settings.tokensEncrypted.startsWith('obf:')) {
+                                        // レガシー形式: 旧XORで復号 → 新形式へ再保存
+                                        json = deobfuscateLegacyFromBase64(this.settings.tokensEncrypted, this.settings.obfuscationSalt || '');
+                                        try {
+                                                const { refresh_token } = JSON.parse(json);
+                                                if (refresh_token) await this.persistTokens({ refresh_token });
+                                        } catch {}
+                                }
+                                if (json) {
+                                        const { refresh_token } = JSON.parse(json);
+                                        if (refresh_token) this.settings.tokens = { refresh_token } as any;
+                                }
+                        }
+                } catch (e) {
+                        console.error('暗号化トークンの復号に失敗:', e);
+                }
+        }
+
+        private async initializeOAuth(): Promise<void> {
+                await initOAuth(this);
+        }
+
+        private registerCommands(): void {
+                initRegisterCommands(this);
+        }
+
+        private setupAutoSyncTimer(): void {
+                initAutoSyncTimer(this);
+        }
 
 	// saveData をオーバーライドし、平文トークンをディスクに書き込まない
 	async saveData(data: any): Promise<void> {
@@ -245,7 +237,7 @@ export default class GoogleCalendarTasksSyncPlugin extends Plugin {
         this.authService.initializeCalendarApi();
 
         // 2. 自動同期タイマーのリセット/セットアップ
-        this.setupAutoSync();
+this.setupAutoSyncTimer();
 
         // 3. HTTP サーバー状態の管理 (ポート変更時のみ再起動)
         const configuredPort = this.settings.loopbackPort;
@@ -322,48 +314,12 @@ export default class GoogleCalendarTasksSyncPlugin extends Plugin {
         await this.syncLogic.runSync(JSON.parse(JSON.stringify(this.settings)), { force: true });
     }
 
-	/** 自動同期を設定 */
-	setupAutoSync() {
-		this.clearAutoSync();
-		if (this.settings.autoSync && this.settings.syncIntervalMinutes >= 1) {
-			const intervalMillis = this.settings.syncIntervalMinutes * 60 * 1000;
-			console.log(`自動同期を ${this.settings.syncIntervalMinutes} 分ごとに設定します。`);
-			this.syncIntervalId = window.setInterval(async () => {
-				const timestamp = moment().format('HH:mm:ss');
-				console.log(`[${timestamp}] 自動同期トリガー`);
-                if (this.isSyncing) {
-					console.warn(`[${timestamp}] 自動同期スキップ: 実行中`);
-					return;
-				}
-                if (!this.settings.tokens) {
-                    console.warn(`[${timestamp}] 自動同期スキップ: 未認証`);
-                    return; // トークンがなければ同期しない
+        /** 自動同期を停止 */
+        clearAutoSync() {
+                if (this.syncIntervalId !== null) {
+                        window.clearInterval(this.syncIntervalId);
+                        this.syncIntervalId = null;
+                        console.log("自動同期タイマーが停止されました。");
                 }
-                // トークンの有効性を確認し、必要ならリフレッシュを試みる
-                const tokenReady = await this.authService.ensureAccessToken();
-                if (!tokenReady) {
-                     console.warn(`[${timestamp}] 自動同期スキップ: トークン取得失敗`);
-                     // ensureAccessToken内でNotice表示や自動同期停止が行われる
-                     return;
-                }
-                // 同期実行
-				console.log(`[${timestamp}] 自動同期実行中...`);
-                // FIX: 設定のスナップショットを渡して競合状態を防止
-				await this.syncLogic.runSync(JSON.parse(JSON.stringify(this.settings)));
-                console.log(`[${timestamp}] 自動同期完了`);
-			}, intervalMillis);
-            console.log(`自動同期タイマー開始 (ID: ${this.syncIntervalId})。初回実行は約 ${moment().add(intervalMillis, 'ms').format('HH:mm')}。`);
-		} else {
-            console.log(`自動同期は無効です (有効: ${this.settings.autoSync}, 間隔: ${this.settings.syncIntervalMinutes} 分)。`);
         }
-	}
-
-	/** 自動同期を停止 */
-	clearAutoSync() {
-		if (this.syncIntervalId !== null) {
-			window.clearInterval(this.syncIntervalId);
-			this.syncIntervalId = null;
-			console.log("自動同期タイマーが停止されました。");
-		}
-	}
 }


### PR DESCRIPTION
## Summary
- split main onload logic into smaller responsibilities
- modularize settings validation, OAuth setup, and command registration
- centralize auto-sync timer management

## Testing
- `npm test` *(fails: vitest: not found; npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b67fa673e883209ab398d17d6badc6