### PR TITLE
fix: preserve request params when fetching GCal events

### DIFF
--- a/src/gcalApi.ts
+++ b/src/gcalApi.ts
@@ -157,7 +157,7 @@ export class GCalApiService {
         do {
             console.log(`GCal イベントページ ${page} を取得中...${label}`);
             params.pageToken = nextPageToken;
-            const response: GaxiosResponse<calendar_v3.Schema$Events> = await this.eventsListWithRetry(params);
+            const response: GaxiosResponse<calendar_v3.Schema$Events> = await this.eventsListWithRetry({ ...params });
             if (response.data.items) events.push(...response.data.items);
             if (response.data.nextSyncToken) nextSyncToken = response.data.nextSyncToken;
             nextPageToken = response.data.nextPageToken ?? undefined;


### PR DESCRIPTION
## Summary
- prevent syncToken from being cleared in recorded events.list calls by cloning params before request

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b681d3aaa08320a2a8ac78b1569780