### PR TITLE
fix: preserve request params when fetching GCal events

### DIFF
--- a/__tests__/gcalApi.spec.ts
+++ b/__tests__/gcalApi.spec.ts
@@ -54,9 +54,10 @@ describe('GCalApiService.eventsListWithRetry', () => {
       .mockResolvedValueOnce({ data: { items: [] } } as any);
 
     vi.useFakeTimers();
-    const promise = (service as any).eventsListWithRetry({ calendarId: 'c' } as calendar_v3.Params$Resource$Events$List);
+    const call = (service as any).eventsListWithRetry({ calendarId: 'c' } as calendar_v3.Params$Resource$Events$List);
+    const resPromise = call.then(res => res);
     await vi.runAllTimersAsync();
-    const res = await promise;
+    const res = await resPromise;
     vi.useRealTimers();
 
     expect(res.data.items).toEqual([]);
@@ -69,9 +70,10 @@ describe('GCalApiService.eventsListWithRetry', () => {
     plugin.calendar.events.list.mockRejectedValue(err);
 
     vi.useFakeTimers();
-    const promise = (service as any).eventsListWithRetry({ calendarId: 'c' } as calendar_v3.Params$Resource$Events$List);
+    const call = (service as any).eventsListWithRetry({ calendarId: 'c' } as calendar_v3.Params$Resource$Events$List);
+    const expectation = expect(call).rejects.toThrow(/events.list failed/);
     await vi.runAllTimersAsync();
-    await expect(promise).rejects.toThrow(/events.list failed/);
+    await expectation;
     vi.useRealTimers();
 
     expect(plugin.calendar.events.list).toHaveBeenCalledTimes(3);

--- a/src/gcalApi.ts
+++ b/src/gcalApi.ts
@@ -157,7 +157,7 @@ export class GCalApiService {
         do {
             console.log(`GCal イベントページ ${page} を取得中...${label}`);
             params.pageToken = nextPageToken;
-            const response: GaxiosResponse<calendar_v3.Schema$Events> = await this.eventsListWithRetry(params);
+            const response: GaxiosResponse<calendar_v3.Schema$Events> = await this.eventsListWithRetry({ ...params });
             if (response.data.items) events.push(...response.data.items);
             if (response.data.nextSyncToken) nextSyncToken = response.data.nextSyncToken;
             nextPageToken = response.data.nextPageToken ?? undefined;


### PR DESCRIPTION
## Summary
- prevent syncToken from being cleared in recorded events.list calls by cloning params before request
- avoid unhandled rejection warnings in retry tests by attaching expectation before timers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68b681d3aaa08320a2a8ac78b1569780