### PR TITLE
Handle port conflicts by closing server before retrying

### DIFF
--- a/__tests__/httpServer.portConflict.spec.ts
+++ b/__tests__/httpServer.portConflict.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as net from 'net';
+import { HttpServerManager } from '../src/httpServer';
+
+class PluginStub {
+  settings: any;
+  constructor(port: number) {
+    this.settings = { loopbackPort: port };
+  }
+  async saveData(data: any) {
+    this.settings = { ...this.settings, ...data };
+  }
+  reconfigureOAuthClient() {}
+  refreshSettingsTab() {}
+}
+
+describe('HttpServerManager', () => {
+  it('cleans up failed servers and leaves only one instance after port conflict', async () => {
+    const blocker = net.createServer();
+    await new Promise<void>((resolve, reject) =>
+      blocker.listen(0, '127.0.0.1', () => resolve())
+    );
+    const occupiedPort = (blocker.address() as net.AddressInfo).port;
+
+    const plugin = new PluginStub(occupiedPort);
+    const manager = new HttpServerManager(plugin as any);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    manager.startServer();
+    await new Promise((r) => setTimeout(r, 300));
+
+    const runningServer = manager.runningServer;
+    expect(runningServer).not.toBeNull();
+    const runningPort = (runningServer!.address() as net.AddressInfo).port;
+    expect(runningPort).toBe(occupiedPort + 1);
+
+    const serverHandles = (process as any)
+      ._getActiveHandles()
+      .filter((h: any) => h instanceof net.Server);
+    expect(serverHandles.length).toBe(2);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      `サーバーをクリーンアップしました: ポート ${occupiedPort}`
+    );
+
+    runningServer!.close();
+    blocker.close();
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -60,6 +60,10 @@ export class HttpServerManager {
 
                 if (error.code === 'EADDRINUSE') {
                     console.warn(`ポート ${portToTry} は使用中です。次のポート (${portToTry + 1}) を試します...`);
+                    try {
+                        newServer.close();
+                        console.log(`サーバーをクリーンアップしました: ポート ${portToTry}`);
+                    } catch {}
                     attemptListen(portToTry + 1);
                 } else if (error.code === 'EACCES') {
                     console.error(`ポート ${portToTry} へのバインドに権限がありません。`, error);


### PR DESCRIPTION
## Summary
- Close and log cleanup of HTTP server before retrying on port conflicts
- Test that port conflicts clean up old servers and only one server remains

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b687d571d8832095e60fafad23fa46