### PR TITLE
Wrap batch execution in timed try/finally

### DIFF
--- a/__tests__/batchProcessor.spec.ts
+++ b/__tests__/batchProcessor.spec.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BatchProcessor } from '../src/batchProcessor';
+import { setDevLogging } from '../src/logger';
+
+const settings = {
+  showNotices: false,
+  maxBatchPerHttp: 50,
+  minDesiredBatchSize: 5,
+  desiredBatchSize: 5,
+  maxInFlightBatches: 1,
+  latencySLAms: 1500,
+  rateErrorCooldownMs: 0,
+  interBatchDelay: 0,
+};
+
+describe('BatchProcessor executeBatches timing', () => {
+  beforeEach(() => setDevLogging(true));
+  afterEach(() => setDevLogging(false));
+
+  test('timeEnd called even on error', async () => {
+    const endSpy = vi.spyOn(console, 'timeEnd').mockImplementation(() => {});
+    const processor = new BatchProcessor(settings as any);
+
+    const ac = new AbortController();
+    ac.abort();
+
+    await expect(
+      processor.executeBatches(
+        [{ method: 'POST', path: '/test', operationType: 'insert' } as any],
+        async () => [],
+        ac.signal,
+      )
+    ).rejects.toThrow('AbortError');
+
+    expect(endSpy).toHaveBeenCalledWith('BatchProcessor: Execute All Batches');
+    endSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- time `BatchProcessor.executeBatches` with a try/finally to ensure the timer ends
- use custom `logger.time/timeEnd` instead of raw console timers
- add a unit test confirming timing cleanup even when an abort error occurs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden on eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68b687d761708320b19368fe8d103181