### PR TITLE
Refactor passphrase encryption to async pbkdf2

### DIFF
--- a/__tests__/security.spec.ts
+++ b/__tests__/security.spec.ts
@@ -20,19 +20,19 @@ function obfuscateLegacy(plain: string, saltB64: string): string {
 }
 
 describe('encryptWithPassphrase/decryptWithPassphrase', () => {
-  it('round-trips', () => {
-    const enc = encryptWithPassphrase('hello', 'pass');
-    const dec = decryptWithPassphrase(enc, 'pass');
+  it('round-trips', async () => {
+    const enc = await encryptWithPassphrase('hello', 'pass');
+    const dec = await decryptWithPassphrase(enc, 'pass');
     expect(dec).toBe('hello');
   });
 
-  it('fails on wrong passphrase', () => {
-    const enc = encryptWithPassphrase('hello', 'pass1');
-    expect(() => decryptWithPassphrase(enc, 'pass2')).toThrow();
+  it('fails on wrong passphrase', async () => {
+    const enc = await encryptWithPassphrase('hello', 'pass1');
+    await expect(decryptWithPassphrase(enc, 'pass2')).rejects.toThrow();
   });
 
-  it('fails on invalid format', () => {
-    expect(() => decryptWithPassphrase('foo', 'pass')).toThrow('Invalid encrypted format');
+  it('fails on invalid format', async () => {
+    await expect(decryptWithPassphrase('foo', 'pass')).rejects.toThrow('Invalid encrypted format');
   });
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -150,7 +150,7 @@ export default class GoogleCalendarTasksSyncPlugin extends Plugin {
                 if (this.settings.tokensEncrypted.startsWith('aesgcm:')) {
                     const pass = this.passphraseCache || this.settings.encryptionPassphrase || null;
                     if (pass) {
-                        const inner = decryptWithPassphrase(this.settings.tokensEncrypted, pass);
+                        const inner = await decryptWithPassphrase(this.settings.tokensEncrypted, pass);
                         json = deobfuscateFromBase64(inner, this.settings.obfuscationSalt!);
                     } else {
                         console.warn('暗号化トークンが存在しますが、パスフレーズが未設定のため復号できません。');
@@ -201,7 +201,7 @@ export default class GoogleCalendarTasksSyncPlugin extends Plugin {
             const pass = this.passphraseCache || this.settings.encryptionPassphrase || null;
             if (pass && pass.length > 0) {
                 try {
-                    this.settings.tokensEncrypted = encryptWithPassphrase(obf, pass);
+                    this.settings.tokensEncrypted = await encryptWithPassphrase(obf, pass);
                     await super.saveData({ ...this.settings, tokens: null });
                 } catch (e) {
                     console.error('AES二重ラップに失敗:', e);


### PR DESCRIPTION
## Summary
- refactor encrypt/decrypt helpers to use async pbkdf2 instead of pbkdf2Sync
- update plugin logic to await asynchronous passphrase operations
- adapt security tests for the new async implementations

## Testing
- `npm test` *(fails: vitest: not found)*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b687da71748320a9be07a83e6161ac