### PR TITLE
Adjust port conflict test for unrefed server

### DIFF
--- a/__tests__/httpServer.portConflict.spec.ts
+++ b/__tests__/httpServer.portConflict.spec.ts
@@ -39,7 +39,11 @@ describe('HttpServerManager', () => {
     const serverHandles = (process as any)
       ._getActiveHandles()
       .filter((h: any) => h instanceof net.Server);
-    expect(serverHandles.length).toBe(2);
+    // The HttpServerManager unrefs its server instance, so only the blocking
+    // test server remains referenced in the active handle list. This ensures
+    // that the failed server was cleaned up properly and no additional
+    // references are left behind.
+    expect(serverHandles.length).toBe(1);
 
     expect(logSpy).toHaveBeenCalledWith(
       `サーバーをクリーンアップしました: ポート ${occupiedPort}`


### PR DESCRIPTION
## Summary
- update port conflict spec to expect only the blocking server in active handles because HttpServerManager unrefs its server

## Testing
- `npm test` *(fails: vitest: not found)*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b68a8221b4832099ed862ef4f9ce21