### PR TITLE
test: add AuthService redirect URI tests

### DIFF
--- a/__tests__/auth.spec.ts
+++ b/__tests__/auth.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { AuthService } from '../src/auth';
+import { DEFAULT_SETTINGS } from '../src/settings';
+
+const mkPlugin = (port: number) => ({
+  settings: { ...DEFAULT_SETTINGS, loopbackPort: port },
+  oauth2Client: null,
+} as any);
+
+describe('AuthService.getRedirectUri', () => {
+  it('returns custom port when valid', () => {
+    const service = new AuthService(mkPlugin(4321));
+    expect(service.getRedirectUri()).toBe('http://127.0.0.1:4321/oauth2callback');
+  });
+
+  it('falls back to default when port out of range', () => {
+    const service = new AuthService(mkPlugin(70000));
+    expect(service.getRedirectUri()).toBe(`http://127.0.0.1:${DEFAULT_SETTINGS.loopbackPort}/oauth2callback`);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AuthService redirect URI behavior

## Testing
- `npm test __tests__/auth.spec.ts` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68dfaf7808320ac25ac3a266bbbc1