### PR TITLE
test: add commonUtils tests

### DIFF
--- a/__tests__/commonUtils.spec.ts
+++ b/__tests__/commonUtils.spec.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'vitest';
+import { DateUtils, TaskMapUtils } from '../src/commonUtils';
+
+describe('DateUtils.isSameDateTime', () => {
+  test('returns true for same timestamp with different timezones', () => {
+    const dt1 = '2023-01-01T12:00:00+09:00';
+    const dt2 = '2023-01-01T03:00:00+00:00'; // same instant
+    expect(DateUtils.isSameDateTime(dt1, dt2)).toBe(true);
+  });
+
+  test('returns false when timestamps differ', () => {
+    const dt1 = '2023-01-01T12:00:00+09:00';
+    const dt2 = '2023-01-01T12:01:00+09:00'; // different time
+    expect(DateUtils.isSameDateTime(dt1, dt2)).toBe(false);
+  });
+});
+
+describe('TaskMapUtils.updateTaskMap and removeFromTaskMap', () => {
+  test('adds and updates mapping correctly', () => {
+    const map: Record<string, string> = {};
+    TaskMapUtils.updateTaskMap(map, 'task1', 'event1');
+    expect(map).toEqual({ task1: 'event1' });
+
+    // update existing mapping
+    TaskMapUtils.updateTaskMap(map, 'task1', 'event2');
+    expect(map).toEqual({ task1: 'event2' });
+  });
+
+  test('removes mapping correctly', () => {
+    const map: Record<string, string> = { task1: 'event1', task2: 'event2' };
+    TaskMapUtils.removeFromTaskMap(map, 'task1');
+    expect(map).toEqual({ task2: 'event2' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for DateUtils.isSameDateTime handling timezone differences
- ensure TaskMapUtils handles add/update/remove correctly

## Testing
- `npx vitest run __tests__/commonUtils.spec.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*


------
https://chatgpt.com/codex/tasks/task_e_68b68dfd34348320a2c6b1546751a728