### PR TITLE
fix: guard against missing PluginSettingTab

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -35,13 +35,20 @@ export const DEFAULT_SETTINGS: GoogleCalendarTasksSyncSettings = {
 };
 
 
-export class GoogleCalendarSyncSettingTab extends PluginSettingTab {
-	plugin: GoogleCalendarTasksSyncPlugin; // 型をメインプラグインクラスに指定
+// Vitest などで `obsidian` モジュールをモックする際、`PluginSettingTab` が
+// undefined になるとクラス継承で TypeError が発生する。ランタイムでの
+// import 時に例外が出ないよう、`PluginSettingTab` が存在しない場合は空の
+// クラスを継承元として使用する。
+// eslint-disable-next-line @typescript-eslint/ban-types
+const SafePluginSettingTab: typeof PluginSettingTab = (PluginSettingTab ?? (class {} as any));
 
-	constructor(app: App, plugin: GoogleCalendarTasksSyncPlugin) { // 型をメインプラグインクラスに指定
-		super(app, plugin);
-		this.plugin = plugin;
-	}
+export class GoogleCalendarSyncSettingTab extends SafePluginSettingTab {
+        plugin: GoogleCalendarTasksSyncPlugin; // 型をメインプラグインクラスに指定
+
+        constructor(app: App, plugin: GoogleCalendarTasksSyncPlugin) { // 型をメインプラグインクラスに指定
+                super(app, plugin);
+                this.plugin = plugin;
+        }
 
 	display(): void {
 		const { containerEl } = this;


### PR DESCRIPTION
## Summary
- avoid TypeError when `PluginSettingTab` is missing by falling back to an empty class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b68ef709e483209a47b4bced395929